### PR TITLE
Add statanim and llmanim to extras

### DIFF
--- a/scripts/default.json
+++ b/scripts/default.json
@@ -1,6 +1,8 @@
 {
     "extras": [
-        "chanim"
+        "chanim",
+        "statanim",
+        "llmanim"
     ],
     "exclude": [
         "manim-ext",


### PR DESCRIPTION
Hi! Requesting to add two Manim extension plugins to the extras list:

- **statanim** (https://pypi.org/project/statanim/) — animated statistical 
  visualisations for Manim: distributions, regression, probability, inference and more.

- **llmanim** (https://pypi.org/project/llmanim/) — LLM-powered animations 
  for Manim.

Both are on PyPI, MIT licensed, and actively maintained.