### PR TITLE
Add qual-manim to extras

### DIFF
--- a/scripts/default.json
+++ b/scripts/default.json
@@ -2,7 +2,8 @@
     "extras": [
         "chanim",
         "statanim",
-        "llmanim"
+        "llmanim",
+        "qual-manim"
     ],
     "exclude": [
         "manim-ext",


### PR DESCRIPTION
This PR adds [`qual-manim`](https://pypi.org/project/qual-manim/) to the `extras` section, since its PyPI name doesn't match the `manim-*` pattern.

qual is a Manim-aware linter that catches render-time errors, visual bugs, and per-frame performance traps in Manim scenes before rendering.

- PyPI: https://pypi.org/project/qual-manim/
- Repository: https://github.com/Poietra/qual
- Docs: https://poietra.github.io/qual/

🤖 Generated with [Claude Code](https://claude.com/claude-code)